### PR TITLE
Basic support for screen blocks that you want to allow to wrap

### DIFF
--- a/myhtml.xsl
+++ b/myhtml.xsl
@@ -372,7 +372,7 @@
       *
       * they either have an attribute of file, 
       * which means load the text from @file.xml,
-      * or use their content
+      * or use their content.
       *
       *-->
   <xsl:template name="add-highlight">
@@ -382,6 +382,12 @@
 <pre class="highlight"><xsl:copy-of select="$contents"/></pre>
   </xsl:template> <!--* name=add-highlight *-->
 
+  <!--*
+      * The optional attribute wrap is used to select
+      * the text-wrapping behavior. By default it does not
+      * wrap (wrap="no") but it can be changed to wrap by setting
+      * wrap="yes".
+      *-->
   <xsl:template match="screen">
 
     <!--* a check since we've changed name to file *-->
@@ -410,7 +416,16 @@
       </xsl:choose></xsl:variable>
 
     <!--* <br/> *-->
-    <div class="screen">
+    <xsl:variable name="class"><xsl:choose>
+      <xsl:when test="boolean(@wrap) and @wrap='yes'">screenwrap</xsl:when>
+    <xsl:when test="(boolean(@wrap) and @wrap='no') or not(boolean(@wrap))">screen</xsl:when>
+    <xsl:otherwise>
+      <xsl:message terminate="yes">
+ ERROR: invaling wrap attribute in screen tag: wrap=<xsl:value-of select="@wrap"/>
+      </xsl:message>
+    </xsl:otherwise></xsl:choose></xsl:variable>
+    
+    <div class="{$class}">
       <xsl:call-template name="add-highlight">
 	<xsl:with-param name="contents" select="$contents"/>
       </xsl:call-template>


### PR DESCRIPTION
The current setup does not make it easy to have wide screen blocks,
since they end up making the display too wide. It is not clear to me
if changes in the HTML5 move (or related CSS changes) have made this
happen, or it always did and the "overflow: auto" rule on these were
never being triggered.

As a simple hack, you can now add a wrap="yes" attribute to screen tags
to allow the text to wrap. This is really meant to be a short-term fix,
but I expect it to remain for a while...