### PR TITLE
If /*/info/breadcrumbs exists then add a "breadcrumb" trail

### DIFF
--- a/CIAODOC.pm
+++ b/CIAODOC.pm
@@ -1654,6 +1654,41 @@ Argh: ahelp reverse dependencies are generally complicated because
 				  }
 				 );
 
+  # Given the url and depth, return the breadcrumb terms
+  #
+  # For testing just return the actual HTML. I've also forgotten
+  # all my Perl ...
+  #
+  XML::LibXSLT->register_function("http://hea-www.harvard.edu/~dburke/xsl/extfuncs",
+				  "get-breadcrumbs",
+				  sub {
+				    my $url = shift;
+                                    my $depth = int(shift) + 1;
+				    my @toks = split(/\//, $url);
+
+				    # remove leading terms
+				    splice(@toks, 0, -$depth);
+
+				    my @counts = reverse (0 .. $#toks);
+
+				    my $out = "";
+				    foreach my $i ( 0 .. $#toks ) {
+					my $count = $counts[$i];
+					my $tok = $toks[$i];
+					if ($out ne "") { $out .= " "; }
+					if ($count == 0) {
+					    $out .= "/ $tok";
+					} else {
+					    my $href;
+					    if ($count == 1) { $href = '.'; }
+					    else { $href = '../' x ($count - 1); }
+					    $out .= "/ <a href='${href}'>$tok</a>";
+					}
+				    }
+
+				    return $out;
+				  }
+				 );
 }
 
 

--- a/common.xsl
+++ b/common.xsl
@@ -440,9 +440,13 @@ if (self == top) {
       </xsl:call-template>
 
       <main id="content">
+	<xsl:call-template name="add-breadcrumbs"/>
 	<div class="wrap">
 	  <xsl:copy-of select="$contents"/>
 	</div>
+	<xsl:call-template name="add-breadcrumbs">
+	  <xsl:with-param name="pos" select="'bottom'"/>
+	</xsl:call-template>
       </main>
 
       <xsl:call-template name="add-footer">
@@ -487,9 +491,13 @@ if (self == top) {
       <xsl:call-template name="add-header"/>
 
       <main id="content">
+	<xsl:call-template name="add-breadcrumbs"/>
 	<div class="wrap">
 	  <xsl:copy-of select="$contents"/>
 	</div>
+	<xsl:call-template name="add-breadcrumbs">
+	  <xsl:with-param name="pos" select="'bottom'"/>
+	</xsl:call-template>
       </main>
 
       <aside id="navbar">
@@ -503,6 +511,25 @@ if (self == top) {
     </body>
   </xsl:template> <!--* add-body-withnavbar *-->
 
+
+  <!--*
+      * Add a breadcrumbs element for navigation if the
+      * breadcrumbs element is set in the info block.
+      *
+      * The styling requires that .breadcrumbs is a child of
+      * #content.
+      *
+      * /Experimental/
+      *-->
+  <xsl:template name="add-breadcrumbs">
+    <xsl:param name="pos" select="'top'"/>
+    <xsl:if test="boolean(//info/breadcrumbs)">
+      <div class="breadcrumbs breadcrumbs-{$pos}">
+	<xsl:value-of disable-output-escaping="yes"
+	    select="extfuncs:get-breadcrumbs($url, $depth)"/>
+      </div>
+    </xsl:if>
+  </xsl:template>
 
   <!--*
       * With the move to HTML5, there are a number of "presentational" tags


### PR DESCRIPTION
A set of links, listing the location of this page within the
hiearachy of the site, in the form

  / site / dir1 / ... / page.html

are created at the top and bottom of the main section of the page,
where each segment (other than page.html) is a link.

The stylesheets need to have something like the following, where the
parent of .breadcrumbs is position: relative.

  position: relative;
}

.breadcrumbs {
  background: #eeeeee;
  font-family: monospace;
  font-size: smaller;
  margin-right: 1em;
  margin-top: 0.5em;
  position: absolute;
  right: 1em;
}

.breadcrumbs-top {
  top: 0.5em;
}

.breadcrumbs-bottom {
  bottom: 0.5em;
}