### PR TITLE
Tweak banner support

### DIFF
--- a/config.dat
+++ b/config.dat
@@ -109,6 +109,11 @@ version_string=4.11
 %searchssi=test /ciao4.11/ciao_search.ssi
 %searchssi=trial /ciao/ciao_search.ssi
 
+# location of the banner page, relative to the top-level directory
+#%sitebanner=live banner.xml
+#%sitebanner=test banner.xml
+#%sitebanner=trial banner.xml
+
 # location of the google analytics ssi
 # only added for the live site in helper.xsl
 googlessi=/ciao4.11/analytics.ssi
@@ -421,6 +426,11 @@ logourl=/sherpa4.11/
 %searchssi=test /sherpa4.11/sherpa_search.ssi
 %searchssi=trial /sds/sherpa/sherpa_search.ssi
 
+# location of the banner page, relative to the top-level directory
+#%sitebanner=live banner.xml
+#%sitebanner=test banner.xml
+#%sitebanner=trial banner.xml
+
 # location of the google analytics ssi
 # only added for the live site in helper.xsl
 googlessi=/sherpa4.11/analytics.ssi
@@ -533,9 +543,10 @@ logourl=/chips4.11/
 %searchssi=test /chips4.11/chips_search.ssi
 %searchssi=trial /sds/chips/chips_search.ssi
 
-# TEST
 # location of the banner page, relative to the top-level directory
-%sitebanner=test banner.xml
+#%sitebanner=live banner.xml
+#%sitebanner=test banner.xml
+#%sitebanner=trial banner.xml
 
 # location of the google analytics ssi
 # only added for the live site in helper.xsl

--- a/publish.pl
+++ b/publish.pl
@@ -262,6 +262,15 @@ my $sitebanner = "";
 $sitebanner = get_config_type( $version_config, "sitebanner", $type )
   if check_config_exists( $version_config, "sitebanner" );
 
+# If the banner is set, ensure we can find it
+#
+if ($sitebanner ne "") {
+  dbg "** checking for sitebanner=$sitebanner depth=$depth";
+  my $sitebannerfile = '../' x ($depth - 1) . $sitebanner;
+  die "ERROR: Unable to find sitebanner=$sitebannerfile\n" unless
+      -e $sitebannerfile;
+}
+
 # google analytics include
 #
 my $googlessi = "";


### PR DESCRIPTION
The publishing script now errors out if the banner file is set but has not been created.

The configs for ciao, sherpa, and chips have banner support added, but commented out.