### PR TITLE
Allow unpublishable directories

### DIFF
--- a/publish.pl
+++ b/publish.pl
@@ -185,7 +185,6 @@ for (my $i = $#dtoks; $i >= 5; $i--) {
     die "Sentinel file $filename was found. Publishing is forbidden!\n"
         if -e $filename;
 }
-die;
 
 $force = 1 if $forceforce;
 

--- a/publish.pl
+++ b/publish.pl
@@ -66,6 +66,11 @@
 #   in the config file, as are the actual stylesheets needed,
 #   unless the --localxslt flag is used to override this.
 #
+# Notes:
+#   This will refuse to publish anything, no matter how many force
+#   statements you use, in a directory containing the file
+#   DO_NOT_PUBLISH.
+#
 # Author:
 #  Doug Burke (dburke@cfa.harvard.edu)
 #
@@ -139,6 +144,12 @@ page b needs info from page a. This is experimental and should be
 carefully, and rarely, used. One consequence is that the output may
 contain place-holder text.
 
+If the directory contains the file DO_NOT_PUBLISH then the script
+will error out, no matter the number of force options used. This is
+to support data directories that contain data used to generate
+files used in the publishing code, but that themselves should not be
+published.
+
 EOD
 
 # this will be mangled later
@@ -159,6 +170,22 @@ die $usage unless
   'localxslt!' => \$localxslt,
   'ignore-missing!' => \$ignoremissinglink,
   'verbose!' => \$verbose;
+
+# check no "sentinel" file indicating this is a not-to-be-published
+# directory; also check up the parent chain (unfortunately no easy
+# way to know when to stop for now, so just assume we have stuff in
+# /data/da/Docs/blah/blah-with-version/ as the base).
+#
+
+my $sentinel = "DO_NOT_PUBLISH";
+
+my @dtoks = split "/", $dname;
+for (my $i = $#dtoks; $i >= 5; $i--) {
+    my $filename = (join "/", @dtoks[0 .. $i]) . "/" . $sentinel;
+    die "Sentinel file $filename was found. Publishing is forbidden!\n"
+        if -e $filename;
+}
+die;
 
 $force = 1 if $forceforce;
 

--- a/publish_all.pl
+++ b/publish_all.pl
@@ -24,6 +24,9 @@
 #  files it thinks are valid - both XML and XML - and then asks you
 #  whether it should process them all.
 #
+#  If it finds a directory that contains the file DO_NOT_PUBLISH then
+#  it automically excludes this directory (and any sub-directories).
+#
 # Options:
 #    --config - used to find perl executable and passed through to publish.pl
 #    --type, --force and --forceforce are passed through to the publish script
@@ -144,6 +147,14 @@ die $usage unless
     'ignore-missing!' => \$ignoremissinglink,
     'verbose!' => \$verbose;
 
+# check no "sentinel" file indicating this is a not-to-be-published
+# directory
+#
+
+my $sentinel = "DO_NOT_PUBLISH";
+die "The file $sentinel is found in this directory. Publishing is forbidden!\n"
+    if -e $sentinel;
+
 $force = 1 if $forceforce;
 
 # Get the name of the perl executable
@@ -233,6 +244,7 @@ $pipe->reader( qw( find . \( -name RCS -o -name SCCS \) -prune -o -print ) );
 
 my %files;
 my %images;
+my %do_not_publish_dirs;
 my $threadindex;
 my $nrej = 0;
 my $nuserrej = 0;
@@ -256,6 +268,43 @@ while ( <$pipe> ) {
     my $fname = pop @dirs;
     my $dname = $dirs[-1];
     my $path  = join "/", @dirs;
+
+    # Reject if this directory contains the sentinel file.
+    #
+    $nrej++, next if exists $do_not_publish_dirs{$path};
+    if (-e "${path}/${sentinel}") {
+	$nrej++;
+	$do_not_publish_dirs{$path} = 1;
+	next;
+    }
+
+    # Check we are not a child of a do-not-publish directory.
+    # I am not sure how we are recursing through the directories,
+    # so can we guarantee that we have processed the parent
+    # first? There are more elegant ways of doing this.
+    #
+    my $end = scalar(@dirs);
+    my $start = scalar(split "/", $prefix);
+ 
+    my $fail = 0;
+    for (my $i = $start - 1; $i < $end; $i++) {
+	my $checkpath = join "/", @dirs[0 .. $i];
+	if (exists $do_not_publish_dirs{$checkpath}) {
+	    print "dbg - skipping $name as $checkpath in excluded directory\n";
+	    $fail = 1;
+	    last;
+	}
+	if ( -e $checkpath . "/" . $sentinel ) {
+	    $do_not_publish_dirs{$checkpath} = 1;
+	    $fail = 1;
+	    last;
+	}
+    }
+
+    if ($fail == 1) {
+	$nrej++;
+	next;
+    }
 
     # user reject; unfortunately this does not work to exclude
     # sub-directories of the excluded directory.
@@ -310,7 +359,7 @@ while ( <$pipe> ) {
     # we reject the download/doc/dmodel directory/contents
     $nrej++, next if $path =~ /download\/doc\/dmodel($|\/)/;
 
-    # last check - is it checked out for editing?
+    # now check - is it checked out for editing?
     # Not 100% convinced about the RCS check
     #
     if ( -e "$path/SCCS/p.$fname" ) {

--- a/publish_all.pl
+++ b/publish_all.pl
@@ -107,6 +107,8 @@ my @prefixes =
    "/data/da/Docs/ciaoweb/ciao411",
    "/data/da/Docs/sherpaweb/ciao411",
    "/data/da/Docs/chipsweb/ciao411",
+   "/data/da/Docs/ciaoweb/ciao412",
+   "/data/da/Docs/sherpaweb/ciao412",
 
    "/data/da/Docs/icxcweb/sds",
 


### PR DESCRIPTION
If the file `DO_NOT_PUBLISH` is found in the working directory, or in any parent directory up to the "base" directory for this site (assumed to be `/data/da/Docs/blah/blah-with-version/`) then refuse to publish. This is to allow the easy inclusion of data, scripts, and ancillary information in the publishing area (since we want to keep them with the docs) without fear of copying them to the website.

Excuse my perl, I am writing in too many different languages nowadays...