### PR TITLE
Add notebook support

### DIFF
--- a/CIAODOC.pm
+++ b/CIAODOC.pm
@@ -100,7 +100,7 @@ my @funcs_util =
 my @funcs_xslt =
   qw(
      translate_file
-     read_xml_file read_xml_string
+     read_xml_file read_xml_string read_html_string
      find_math_pages
     );
 my @funcs_cfg  =
@@ -147,6 +147,7 @@ sub extract_filename ($);
  
 sub read_xml_file ($);
 sub read_xml_string ($);
+sub read_html_string ($);
 sub translate_file ($$;$);
 sub translate_file_lang ($$$;$);
 
@@ -441,6 +442,14 @@ sub extract_filename ($) { return (split( "/", $_[0] ))[-1]; }
     dbg " - about to parse XML chunk, first line='$firstline'";
     $parser->parse_string($str)
       or die "ERROR: unable to parse XML string, start='$firstline'\n";
+  }
+
+  sub read_html_string ($) {
+    my $str = shift;
+    my $firstline = (split(/\n/,$str))[0];
+    dbg " - about to parse HTML chunk, first line='$firstline'";
+    $parser->parse_html_string($str)
+      or die "ERROR: unable to parse HTML string, start='$firstline'\n";
   }
 
   # TODO:

--- a/common.xsl
+++ b/common.xsl
@@ -97,17 +97,21 @@
       *-->
   <xsl:template name="add-sao-metadata">
     <xsl:param name="title"/>
+    <!-- for now relax this, as seeing odd behavior in notebook.xsl
     <xsl:if test="not(boolean($title))">
       <xsl:message terminate="yes">
  Internal Error: add-sao-metadata called but title parameter not set.
       </xsl:message>
     </xsl:if>
+    -->
 
     <xsl:if test="$favicon != ''">
       <link rel="icon" href="{$favicon}"/>
     </xsl:if>
 
-    <meta name="title"><xsl:attribute name="content"><xsl:value-of select="$title"/></xsl:attribute></meta>
+    <xsl:if test="boolean($title)">
+      <meta name="title"><xsl:attribute name="content"><xsl:value-of select="$title"/></xsl:attribute></meta>
+    </xsl:if>
     <meta name="creator" content="SAO-HEA"/>
     <!-- a language tag on the html element is now used
     <meta http-equiv="content-language" content="en-US"/>

--- a/extract_notebook.py
+++ b/extract_notebook.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+
+"""
+
+Usage:
+
+  ./extract_notebook.py nbfile outdir
+
+Aim:
+
+Extract the notebook components - that is the HTML of the
+notebook and the PNG files - and write them to the output
+directory. The screen output lists, one per line, the
+names of the files that are created.
+
+This requires that the folowing Python packages are installed:
+  nbconvert >= 6.0
+
+"""
+
+import os
+import sys
+
+import nbformat
+
+from traitlets.config import Config
+
+from nbconvert import HTMLExporter
+
+
+def convert(nbfile, outdir):
+
+    if not nbfile.endswith('.ipynb'):
+        raise ValueError(f'nbfile does not end in .ipynb - {nbfile}')
+
+    if not os.path.isdir(outdir):
+        raise IOError(f'Output directory does not exist: {outdir}')
+
+    head = nbfile[:-6]
+
+    with open(nbfile, 'r') as fh:
+        nb = nbformat.reads(fh.read(), as_version=4)
+
+    thisdir = os.path.dirname(os.path.realpath(__file__))
+
+    # Convert the header
+    #
+    config = Config()
+    config.HTMLExporter.template_file = os.path.join(thisdir, 'templates', 'fakehdr.html.j2')
+
+    exporter = HTMLExporter(config=config)
+    (body, resources) = exporter.from_notebook_node(nb)
+
+    # Write out the body
+    out = os.path.join(outdir, f'{head}-head')
+    open(out, 'w').write(body)
+    print(out)
+
+    # Convert the main body
+    #
+    config = Config()
+    config.HTMLExporter.preprocessors = ['nbconvert.preprocessors.ExtractOutputPreprocessor']
+    config.ExtractOutputPreprocessor.output_filename_template = head + '_{unique_key}_{cell_index}_{index}{extension}'
+
+    config.HTMLExporter.template_file = os.path.join(thisdir, 'templates', 'index.html.j2')
+
+    exporter = HTMLExporter(config=config)
+    (body, resources) = exporter.from_notebook_node(nb)
+
+    # Write out the body
+    out = os.path.join(outdir, head)
+    open(out, 'w').write(body)
+    print(out)
+
+    # Write out the file contents
+    for key, cnt in resources['outputs'].items():
+
+        out = os.path.join(outdir, key)
+        open(out, 'wb').write(cnt)
+        print(out)
+
+
+if __name__ == "__main__":
+
+    if len(sys.argv) != 3:
+        sys.stderr.write(f"Usage: {sys.argv[0]} nbfile outdir\n")
+        sys.exit(1)
+
+    convert(sys.argv[1], sys.argv[2])

--- a/notebook.xsl
+++ b/notebook.xsl
@@ -196,25 +196,6 @@
 	  <!-- add in navbar header contents -->
 	  <xsl:value-of select="$notebook_header" disable-output-escaping="yes"/>
 
-	  <!-- *
-	       * HACK
-	       *
-	       * Version 6.0.2 of nbconvert seems to force the width of
-               * multi-line output sections to match the "Out [x]"
-               * section when using the lab template.
-	       *
-	       * It's not at all obvious why this happens but
-               * I have spent way too much time chasing my tail with
-               * this so it's hack time.
-	       *
-	       *-->
-	  <style>
-div.jp-OutputPrompt {
-background: orange;
-  flex: 0 0 auto;
-}
-	  </style>
-	  
 	</head>
 
 	<!-- * create the page contents *-->

--- a/notebook.xsl
+++ b/notebook.xsl
@@ -195,6 +195,25 @@
 
 	  <!-- add in navbar header contents -->
 	  <xsl:value-of select="$notebook_header" disable-output-escaping="yes"/>
+
+	  <!-- *
+	       * HACK
+	       *
+	       * Version 6.0.2 of nbconvert seems to force the width of
+               * multi-line output sections to match the "Out [x]"
+               * section when using the lab template.
+	       *
+	       * It's not at all obvious why this happens but
+               * I have spent way too much time chasing my tail with
+               * this so it's hack time.
+	       *
+	       *-->
+	  <style>
+div.jp-OutputPrompt {
+background: orange;
+  flex: 0 0 auto;
+}
+	  </style>
 	  
 	</head>
 

--- a/notebook.xsl
+++ b/notebook.xsl
@@ -1,0 +1,253 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE xsl:stylesheet>
+
+<!--* 
+    * Convert an XML web page into an HTML one
+    * for notebooks
+    *
+    * info/notebook contains the notebook page
+    *
+    *-->
+
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:exsl="http://exslt.org/common"
+  xmlns:extfuncs="http://hea-www.harvard.edu/~dburke/xsl/extfuncs"
+  extension-element-prefixes="exsl extfuncs">
+
+  <!--*
+      * Options specific to notebooks
+      *   the contents of the header
+      *   the notebook itself
+      *-->
+  <xsl:param name="notebook_header" select='""'/>
+  <xsl:param name="notebook_contents" select='""'/>
+  
+  <!--* Change this if the filename changes *-->
+  <xsl:variable name="hack-import-page" select="extfuncs:register-import-dependency('notebook.xsl')"/>
+
+  <xsl:output method="text"/>
+
+  <!--* we place this here to see if it works (was in header.xsl and wasn't working
+      * - and it seems to
+      *-->
+  <!--* a template to output a new line (useful after a comment)  *-->
+  <xsl:template name="newline">
+<xsl:text> 
+</xsl:text>
+  </xsl:template>
+
+  <!--* load in the set of "global" parameters *-->
+  <xsl:include href="globalparams.xsl"/>
+
+  <!--* include the stylesheets AFTER defining the variables *-->
+  <xsl:include href="helper.xsl"/>
+  <xsl:include href="links.xsl"/>
+  <xsl:include href="myhtml.xsl"/>
+
+  <!--*
+      * top level: create
+      *   index.html
+      *
+      *-->
+  <xsl:template match="/">
+
+    <!--* check the params are okay *-->
+    <xsl:call-template name="is-site-valid"/>
+    <xsl:call-template name="check-param-ends-in-a-slash">
+      <xsl:with-param name="pname"  select="'install'"/>
+      <xsl:with-param name="pvalue" select="$install"/>
+    </xsl:call-template>
+    <xsl:call-template name="check-param-ends-in-a-slash">
+      <xsl:with-param name="pname"  select="'canonicalbase'"/>
+      <xsl:with-param name="pvalue" select="$canonicalbase"/>
+    </xsl:call-template>
+
+    <!--* we only want the top-level notebook *-->
+    <xsl:apply-templates select="/notebook"/>
+
+  </xsl:template> <!--* match=/ *-->
+
+  <!--* 
+      * create: <page>.html
+      *-->
+
+  <xsl:template match="/notebook">
+
+    <xsl:variable name="filename"><xsl:value-of select="$install"/><xsl:value-of select="$pagename"/>.html</xsl:variable>
+
+    <!--* output filename to stdout *-->
+    <xsl:value-of select="$filename"/><xsl:call-template name="newline"/>
+
+    <!--*
+        * create HTML5 document, see
+        * http://w3c.github.io/html/syntax.html#doctype-legacy-string
+        * http://www.microhowto.info/howto/generate_an_html5_doctype_using_xslt.html
+        * https://stackoverflow.com/a/19379446
+        *
+        * Not sure that version="5.0" is actually working properly
+        * (or maybe my libxslt is too old)
+	*-->
+    <xsl:document href="{$filename}" method="html" media-type="text/html"
+                  doctype-system="about:legacy-compat"
+		  version="5.0">
+
+      <!--* we start processing the XML file here *-->
+      <html lang="en-US">
+
+	<!--*
+	    * make the HTML head node
+	    * - this is a manual version of add-htmlhead[-standard]
+	    *-->
+	<xsl:variable name="title"><xsl:choose>
+	      <xsl:when test="boolean(//notebook/info/title/long)"><xsl:value-of select="info/title/long"/></xsl:when>
+	      <xsl:when test="boolean(//notebook/info/title/short)"><xsl:value-of select="info/title/short"/></xsl:when>
+	      <xsl:otherwise>
+		<xsl:message terminate="yes">
+ ERROR no info/title block
+		</xsl:message>
+	      </xsl:otherwise>
+	    </xsl:choose></xsl:variable>
+
+	<head>
+	  <title><xsl:value-of select="$title"/></title>
+
+	  <!--* any meta information to add ? *-->
+	  <xsl:apply-templates select="info/metalist"/>
+
+	  <!--* any scripts ? *-->
+	  <xsl:apply-templates select="info/htmlscripts"/>
+
+	  <xsl:variable name="nmath" select="count(//math) + count(//inlinemath)"/>
+	  <xsl:if test="$use-mathjax = 1 and ($nmath != 0)">
+	    <xsl:if test="$mathjaxpath = ''">
+	      <xsl:message terminate="yes">
+ ERROR: use-mathjax=1 but mathjaxpath is unset and the page contains math tags!
+              </xsl:message>
+	    </xsl:if>
+
+	    <script src="{$mathjaxpath}"/>
+	  </xsl:if>
+
+	  <!--* add main stylesheets *-->
+	  <xsl:choose>
+	    <xsl:when test="$site='iris'">
+	      <link rel="stylesheet" title="Stylesheet for Iris pages" href="{$cssfile}"/>
+	      <link rel="stylesheet" title="Stylesheet for Iris pages" media="print" href="{$cssprintfile}"/>
+	    </xsl:when>
+	 
+	    <xsl:when test="$site='csc'">
+	      <link rel="stylesheet" title="Stylesheet for CSC pages" href="{$cssfile}"/>
+	      <link rel="stylesheet" title="Stylesheet for CSC pages" media="print" href="{$cssprintfile}"/>
+	    </xsl:when>
+	 
+	    <xsl:otherwise>
+	      <link rel="stylesheet" title="Default stylesheet for CIAO-related pages" href="{$cssfile}"/>
+	      <link rel="stylesheet" title="Default stylesheet for CIAO-related pages" media="print" href="{$cssprintfile}"/>
+	    </xsl:otherwise>
+	  </xsl:choose>
+
+	  <xsl:variable name="canonicalurl"><xsl:choose>
+	    <xsl:when test="$canonicalbase = ''">
+	      <xsl:message terminate="no">
+ DEVELOPMENT WARNING: no canonicalbase parameter so falling back to url=<xsl:value-of select="$url"/>
+  (if you see this warning tell Doug!)
+              </xsl:message>
+	      <xsl:choose>
+		<xsl:when test="$url != ''"><xsl:value-of select="$url"/></xsl:when>
+		<xsl:otherwise>
+		  <xsl:message terminate="no">
+ WARNING: page has no canonical link (missing canonicalbase/url params)
+		  </xsl:message>
+		</xsl:otherwise>
+	      </xsl:choose>
+	    </xsl:when>
+	    <xsl:when test="$pagename != ''"><xsl:value-of select="concat($canonicalbase, $pagename, '.html')"/></xsl:when>
+	    <xsl:otherwise>
+	      <xsl:message terminate="no">
+ WARNING: page has no canonical link (missing page/pagename)
+	      </xsl:message>
+	    </xsl:otherwise>
+	  </xsl:choose></xsl:variable>
+	  
+	  <xsl:if test="$canonicalurl != ''">
+	    <xsl:variable name="cpos" select="string-length($canonicalurl) - 10"/>
+	    <xsl:if test="$cpos &lt; 1">
+	      <xsl:message terminate="yes">
+ ERROR: canonicalurl=<xsl:value-of select="$canonicalurl"/> is too short!
+	      </xsl:message>
+	    </xsl:if>
+	    <xsl:choose>
+	      <xsl:when test="substring($canonicalurl, $cpos) = '/index.html'">
+		<link rel="canonical" href="{substring($canonicalurl, 1, $cpos)}"/>
+	      </xsl:when>
+	      <xsl:otherwise>
+		<link rel="canonical" href="{$canonicalurl}"/>
+	      </xsl:otherwise>
+	    </xsl:choose>
+	  </xsl:if>
+
+	  <xsl:apply-templates select="info/css" mode="header"/>
+
+	  <xsl:call-template name="add-sao-metadata">
+	    <xsl:with-param name="title" select="normalize-space($title)"/>
+	  </xsl:call-template>
+
+	  <!-- add in navbar header contents -->
+	  <xsl:value-of select="$notebook_header" disable-output-escaping="yes"/>
+	  
+	</head>
+
+	<!-- * create the page contents *-->
+	<xsl:apply-templates select="text"/>
+
+      </html>
+
+    </xsl:document>
+  </xsl:template> <!--* match=page *-->
+
+  <xsl:template match="text[boolean(//notebook/info/navbar)]">
+
+    <xsl:call-template name="add-body-withnavbar">
+      <xsl:with-param name="contents">
+	<xsl:apply-templates/>
+      </xsl:with-param>
+      <xsl:with-param name="navbar">
+	<xsl:call-template name="add-navbar">
+	  <xsl:with-param name="name" select="//notebook/info/navbar"/>
+	</xsl:call-template>
+      </xsl:with-param>
+    </xsl:call-template>
+
+  </xsl:template> <!-- text with navbar -->
+
+  <!-- no navbar -->
+  <xsl:template match="text">
+
+    <xsl:call-template name="add-body-nonavbar">
+      <xsl:with-param name="contents">
+	<xsl:apply-templates/>
+      </xsl:with-param>
+    </xsl:call-template>
+
+  </xsl:template> <!--* text without navbar *-->
+
+  <!--*
+      * Add the notebook as
+      *    title                  CURRENTLY NOT IMPLEMENTED
+      *    [link to notebook]
+      *    notebook_contents
+      *-->
+  <xsl:template match="notebook">
+    <div class="notebook">
+      <p class="notebook-link">
+	View the
+	<a><xsl:attribute name="href"><xsl:value-of select="//info/notebook"/></xsl:attribute>notebook</a>.
+      </p>
+    
+      <xsl:value-of select="$notebook_contents" disable-output-escaping="yes"/>
+    </div>
+  </xsl:template>
+      
+  
+</xsl:stylesheet>

--- a/publish.pl
+++ b/publish.pl
@@ -1581,8 +1581,16 @@ sub xml2html_notebook ($) {
     #
     # Can we rely on XML::LibXML to parse it?
     #
-    my $raw_html = qx "jupyter nbconvert --to html ${nb} --stdout";
+    my $template = "lab";
+    # my $template = "classic";
+    my $raw_html = qx "jupyter nbconvert --to html ${nb} --template ${template} --stdout";
     dbg "Ran nbconvert";
+
+    # Clean up the HTML as it can contain <DEPRECATED> </DEPRECATED>
+    # comments which breaks everything.
+    #
+    $raw_html =~ s/<DEPRECATED>//g;
+    $raw_html =~ s/<\/DEPRECATED>//g;
 
     my $htmldom = read_html_string($raw_html);
     my $hnode = $htmldom->documentElement();

--- a/publish.pl
+++ b/publish.pl
@@ -758,7 +758,7 @@ sub basic_params ($) {
   
     my $url = "${outurl}${in}.html";
 
-    return {
+    my $out = {
 	    type => $$opts{type},
 	    site => $$opts{site},
 	    lastmod => $$opts{lastmod},
@@ -790,8 +790,15 @@ sub basic_params ($) {
 
 	    ignoremissinglink => $ignoremissinglink,
 
-
 	   };
+
+    # hack way to copy over extra keywords
+    while (my ($key, $value) = each %$opts) {
+	next unless $key =~ /^COPY-/;
+	$$out{substr $key, 5} = $value;
+    }
+
+    return $out;
 
 } # basic_params
 
@@ -1523,6 +1530,109 @@ sub xml2html_thread ($) {
 
 } # sub: xml2html_thread
 
+# xml2html_notebook - called by xml2html
+#
+# The notebook element is used to structure the page,
+# and mark where the notebook goes.
+#
+# The notebook is defined in the metadata; it is assumed
+# to match the name of the file but does not need to be.
+#
+sub xml2html_notebook ($) {
+    my $opts = shift;
+
+    my $in     = $$opts{xml};
+    my $dom    = $$opts{xml_dom};
+    my $outdir = $$opts{outdir};
+    my $outurl = $$opts{outurl};
+
+    print "Parsing [notebook]: $in\n";
+
+    my $rnode = $dom->documentElement();
+
+    # info/notebook contains the ipynb name
+    #
+    my @nbs = $rnode->findnodes('info/notebook');
+    die "No info/notebook node in $in\n" if $#nbs == -1;
+    die "Mutiple info/notebook nodes in $in\n" unless $#nbs == 0;
+
+    my $nb = $nbs[0]->textContent;
+    dbg "Found notebook=$nb";
+
+    die "Unable to find notebook=$nb\n" unless -f $nb;
+    die "notebook does not end in .ipynb\n" unless $nb =~ '\.ipynb\z';
+
+    my @pages = ("${outdir}${in}.html", "${outdir}${nb}");
+    return if should_we_skip $in, @pages;
+    print "\n";
+
+    # If we've got this far we can remove the converted HTML file
+    # (it is checked bu xml2html_basic). Does this help?
+    #
+    myrm $pages[0];
+
+    # Convert the notebook using nbconvert.
+    # This is currently ***VERY SIMPLE*** and we should use
+    # our own templates to do the conversion.
+    #
+    # The current approach is to extract
+    #  - the header information (script and style elements)
+    #  - the body contents
+    #
+    # Can we rely on XML::LibXML to parse it?
+    #
+    my $raw_html = qx "jupyter nbconvert --to html ${nb} --stdout";
+    dbg "Ran nbconvert";
+
+    my $htmldom = read_html_string($raw_html);
+    my $hnode = $htmldom->documentElement();
+
+    # Not ideal, building the string up like this
+    my $htmlhead = "";
+    foreach my $node ($hnode->findnodes('head/*')) {
+	my $name = $node->nodeName;
+	next unless $name eq "script" or $name eq "style" or $name eq "link";
+
+	# convert <script src="..."/> to <script src="..."></script>
+	#
+	my $cts = $node->toString();
+
+	if ($cts =~ '<script src.*"/>') {
+	    $cts = substr $cts, 0, -2;
+	    $cts .= '></script>';
+	}
+
+	# replace <![CDATA[..]]> constructs with xx
+	#
+	$cts =~ s/<!\[CDATA\[(.*)\]\]>/$1/sm;
+
+	$htmlhead .= $cts;
+    }
+    die "No HEAD content\n" if $htmlhead eq '';
+
+    my @htmlbody = $hnode->findnodes('body');
+    die "Unexpected body contents\n" unless $#htmlbody == 0;
+
+    $$opts{'COPY-notebook_header'} = $htmlhead;
+    $$opts{'COPY-notebook_contents'} = $htmlbody[0]->toString();
+
+    # Handle the notebook using xml2html_basic
+    #
+    $$opts{pagename} = $in;
+
+    xml2html_basic "notebook", "notebook", $opts;
+
+    # Copy over the ipynb file
+    #
+    my $out = "${outdir}$nb";
+    mycp $nb, $out;
+    print "  copied    : $nb\n";
+
+    my $url = "${outurl}${in}.html";
+    print "\nThe page can be viewed at:\n  ${url}\n\n";
+
+} # sub: xml2html_notebook
+
 # die_if_icxc $root
 #
 # dies if the site (global variable $site) is equal
@@ -1689,6 +1799,9 @@ sub process_xml ($$) {
 	    #   a) need to know about them to clean up beforehand
 	    #   b) remove the <?xml... line from the 'slugs'/included files
 	    xml2html_basic 'relnotes', 'relnotes', $opts;
+	} elsif ( $root eq "notebook" ) {
+	    die_if_icxc $root;
+	    xml2html_notebook $opts;
 	} else {
 	  # We have some "non-publishing" XML files on iCXC (they are used
 	  # to create other XML files that can be published), so skip them

--- a/templates/conf.json
+++ b/templates/conf.json
@@ -1,0 +1,6 @@
+{
+  "base_template": "lab",
+  "mimetypes": {
+    "text/html": true
+  }
+}

--- a/templates/fakehdr.html.j2
+++ b/templates/fakehdr.html.j2
@@ -1,0 +1,25 @@
+{% from 'mathjax.html.j2' import mathjax %}
+
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<script src="{{ resources.require_js_url }}"></script>
+
+{% for css in resources.inlining.css -%}
+  <style type="text/css">
+    {{ css }}
+  </style>
+{% endfor %}
+
+{{ resources.include_css("static/index.css") }}
+{{ resources.include_css("static/theme-light.css") }}
+
+<style type="text/css">
+a.anchor-link {
+   display: none;
+}
+.highlight  {
+    margin: 0.4em;
+}
+</style>
+
+{{ mathjax() }}

--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -1,0 +1,10 @@
+{%- extends 'base.html.j2' -%}
+{% from 'mathjax.html.j2' import mathjax %}
+{% from 'jupyter_widgets.html.j2' import jupyter_widgets %}
+
+
+{%- block body_header -%}
+{%- endblock body_header -%}
+
+{% block body_footer %}
+{% endblock body_footer %}


### PR DESCRIPTION
The initial support for IPython notebooks. The idea is that you create a .xml file containing something like the following (here `sherpa-flux.xml`)

```
<?xml version="1.0" encoding="us-ascii" ?>
<notebook>
  <info>
    <notebook>sherpa-flux.ipynb</notebook>
    <title>
      <long>CIAO: calculating fluxes with Sherpa</long>
      <short>CIAO: Sherpa and fluxes</short>
    </title>
    <version>4.12</version>
  </info>

  <text>
    <notebook/>
  </text>
</notebook>
```

So you can add extra HTML around the notebook element. You need the notebook in the same directory and they should both get published.