### PR TITLE
myhtml: better-handle item tags

### DIFF
--- a/myhtml.xsl
+++ b/myhtml.xsl
@@ -1787,4 +1787,14 @@ ERROR: section tag has an empty id attribute.
     </xsl:message>
   </xsl:template>
 
+  <!--*
+      * argh; using xi:include is too easy to mess up and
+      * include the wrapper, so let's catch it and just
+      * process it's contents.
+      *-->
+  <xsl:template match="item">
+    <xsl:message terminate="no"> note: processing item tag (hopefully from xi:xinclude)</xsl:message>
+    <xsl:apply-templates/>
+  </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
The way Ihave set up the xi:include handling we often end up including the "item" tag used to hold the contents. As this is so common let's just process the contents of these tags, and let the user know it's done in case something funky is going on (but who's going to track this ...).