### PR TITLE
myhtml: do not poit out processing an item tag

### DIFF
--- a/myhtml.xsl
+++ b/myhtml.xsl
@@ -1836,11 +1836,10 @@ ERROR: section tag has an empty id attribute.
 
   <!--*
       * argh; using xi:include is too easy to mess up and
-      * include the wrapper, so let's catch it and just
-      * process it's contents.
+      * include the wrapper, so let's catch the tag and process
+      * the contents.
       *-->
   <xsl:template match="item">
-    <xsl:message terminate="no"> note: processing item tag (hopefully from xi:xinclude)</xsl:message>
     <xsl:apply-templates/>
   </xsl:template>
 


### PR DESCRIPTION
I had decided to add a warning so that we could see if we are skipping a "legitimate" item tag, but it's too noisy, so just skip. I am assuming that missing any valid item tag would lead to HTML validation issues, so we don't need to worry.