### PR TITLE
threadindex: improve HTML validation

### DIFF
--- a/common.xsl
+++ b/common.xsl
@@ -439,8 +439,12 @@ if (self == top) {
     </xsl:if>
 
     <body class="nonavbar">
-      <!-- copy the attributes of the text node into the body element-->
-      <xsl:copy-of select="@*"/>
+      <!--*
+	  * copy the attributes of the text node into the body element
+	  * - ideally we'd just select the known supported values,
+	  *   but that's hard to set up
+      -->
+      <xsl:copy-of select="@*[name() != 'name']"/>
 
       <xsl:call-template name="add-disclaimer"/>
       <xsl:call-template name="add-header">
@@ -508,8 +512,12 @@ if (self == top) {
 
     <body class="withnavbar">
 
-      <!-- copy the attributes of the text node into the body element-->
-      <xsl:copy-of select="@*"/>
+      <!--*
+	  * copy the attributes of the text node into the body element
+	  * - ideally we'd just select the known supported values,
+	  *   but that's hard to set up
+      -->
+      <xsl:copy-of select="@*[name() != 'name']"/>
 
       <xsl:call-template name="add-disclaimer"/>
       <xsl:call-template name="add-header"/>

--- a/threadindex_common.xsl
+++ b/threadindex_common.xsl
@@ -51,13 +51,20 @@
       <div class="threadsublist">
 	<h4><xsl:apply-templates select="title" mode="show"/></h4>
 
+	<!-- we have now added synopsis blocks here, so need to handle
+	     this -->
 	<xsl:if test="boolean(text)">
+	  <xsl:message terminate="no">See Doug about this message</xsl:message>
 	  <xsl:apply-templates select="text"/>
+	</xsl:if>
+
+	<xsl:if test="boolean(synopsis)">
+	  <xsl:apply-templates select="synopsis" mode="index-page"/>
 	</xsl:if>
 
 	<ul>
 	  <!--* we do not want to process the title element here *-->
-	  <xsl:apply-templates select="*[name() != 'title' and name() != 'text']" mode="threadindex"/>
+	  <xsl:apply-templates select="*[name() != 'title' and name() != 'text' and name() != 'synopsis']" mode="threadindex"/>
 	</ul>
 	<!--* do we need a spacer? *-->
 	<xsl:if test="name(following-sibling::*[1]) = 'item'">


### PR DESCRIPTION
Turns out we use synopsis more than I'd planned, and also needed to avoid unwanted attributes from beibg set on the body tag (this latter just fixes the current problem, it would be nice to "do it properly" but that's hard, and HTML5 is a living standard so it's hard to do well).