### PR TITLE
config: add explicit versions for some CSC 2.1 links

### DIFF
--- a/config.dat
+++ b/config.dat
@@ -804,21 +804,21 @@ texttitlepostfix=CSC
 %cssprint=trial /sds/csc2.1/csc.print.css
 
 # favicon location
-%favicon=live /csc/favicon.ico
-%favicon=test /cscfavicon.ico
+%favicon=live /csc2.1/favicon.ico
+%favicon=test /csc2.1/favicon.ico
 %favicon=trial /sds/csc/favicon.ico
 
 %newsfile=live /proj/web-cxc/htdocs/csc2.1/news.html
 %newsfile=test /proj/web-cxc-dmz-prev/htdocs/csc2.1/news.html
 %newsfile=trial /proj/web-cxc-dmz-test/htdocs/csc2.1/news.html
 
-%newsurl=live /csc/news.html
-%newsurl=test /csc/news.html
+%newsurl=live /csc2.1/news.html
+%newsurl=test /csc2.1/news.html
 %newsurl=trial /sds/csc/news.html
 
 # I do not think these are used by CSC site
-%watchouturl=live /csc/watchout.html
-%watchouturl=test /csc/watchout.html
+%watchouturl=live /csc2.1/watchout.html
+%watchouturl=test /csc2.1/watchout.html
 %watchouturl=trial /sds/csc/watchout.html
 
 logoimage=imgs/csc_logo_navbar.jpg
@@ -831,7 +831,7 @@ logourl=/csc2.1/
 
 # location of the google analytics ssi
 # only added for the live site in helper.xsl
-googlessi=/csc2/analytics.ssi
+googlessi=/csc2.1/analytics.ssi
 
 # MathJax location
 %mathjaxpath=live /ciao4.16/mathjax3/tex-chtml.js


### PR DESCRIPTION
Not entirely sure whether we really care about whether we use the actual URL or the "generic" version here.