### PR TITLE
publish: use dbg for skipped files from publish_all

### DIFF
--- a/publish_all.pl
+++ b/publish_all.pl
@@ -289,7 +289,7 @@ while ( <$pipe> ) {
     for (my $i = $start - 1; $i < $end; $i++) {
 	my $checkpath = join "/", @dirs[0 .. $i];
 	if (exists $do_not_publish_dirs{$checkpath}) {
-	    print "dbg - skipping $name as $checkpath in excluded directory\n";
+	    dbg "dbg - skipping $name as $checkpath in excluded directory\n";
 	    $fail = 1;
 	    last;
 	}


### PR DESCRIPTION
Using dbg doesn't truly help, since instead of now always displaying it we now always hide it, but it's a better default (now we know the skip-file logic is working).