### PR TITLE
Add feed styling

### DIFF
--- a/news.xsl
+++ b/news.xsl
@@ -157,7 +157,7 @@
     <xsl:for-each select=".">
 
     <!-- create summary and id -->
-    <div class="newsitem">
+    <article class="newsitem">
       <h3>
 	<xsl:attribute name="id">
 	  <xsl:text>item-</xsl:text>
@@ -170,7 +170,7 @@
       <div>
       <xsl:apply-templates select="desc/*"/>
       </div>
-    </div>
+    </article>
     </xsl:for-each> 
   </xsl:template> 
   <!-- end main bug content template -->
@@ -208,7 +208,12 @@
       </xsl:message>
     </xsl:if>
 
-    <xsl:value-of select="concat($daynum,' ',$month,' ',$year)"/>
+    <time>
+      <xsl:attribute name="datetime">
+	<xsl:value-of select="pubdate"/>
+      </xsl:attribute>
+      <xsl:value-of select="concat($daynum,' ',$month,' ',$year)"/>
+    </time>
   </xsl:template>
 
   <xsl:template name="calculate-pubdate-feed">

--- a/news.xsl
+++ b/news.xsl
@@ -116,7 +116,19 @@
     <xsl:variable name="filename"><xsl:value-of select="$install"/>feed.xml</xsl:variable>
 
     <!--* create document *-->
-    <xsl:document href="{$filename}">
+    <xsl:document href="{$filename}"
+		  method="xml" version="1.0" omit-xml-declaration="no">
+
+      <!-- See
+	https://github.com/genmon/aboutfeeds/blob/main/tools/pretty-feed-v3.xsl
+        for styling info
+	-->
+
+      <xsl:processing-instruction name="xml-stylesheet">
+	<!-- TODO: the href value could be configurable -->
+	<xsl:text>href="pretty-feed-v3.xsl" type="text/xsl"</xsl:text>
+      </xsl:processing-instruction>
+      <xsl:call-template name="newline"/>
 
       <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
 	<channel><xsl:call-template name="newline"/> 


### PR DESCRIPTION
Ensure the feed.xml page has some minor styling for anyone who clicks on the link.

Tweak the HTML output of the news page to use more HTML5 compliant markup (e.g. article rather than div, and wrap a time value in a time element).