### PR TITLE
threads: use section for overview section

### DIFF
--- a/thread_common.xsl
+++ b/thread_common.xsl
@@ -108,10 +108,10 @@
       </xsl:when> <!--* text/introduction *-->
 
       <xsl:when test="boolean(text/overview)">
-	<div id="overview">
+	<section id="overview">
 	  <h2>Overview</h2>
 	  <xsl:apply-templates select="text/overview"/>
-	</div>
+	</section>
 	<xsl:call-template name="add-hr-strong"/>
       </xsl:when> <!--* text/overview *-->
 


### PR DESCRIPTION
Switch to section rather than div for the overview. This requires a change to the CIAO css file (to use '#overview' rather than 'div#overview').