### PR TITLE
Allow multiple CSS blocks when using pygmentize

### DIFF
--- a/publish.pl
+++ b/publish.pl
@@ -1862,13 +1862,14 @@ sub process_xml ($$) {
 		    $tempnode->appendChild($cssnode);
 		}
 
-	    } elsif ($ncss == 1) {
+	    } else {
+		# Just add to the **first** node for now, which will
+		# hopefully allow us to over-ride any settings if
+		# necessary.
+		#
 		my $cssnode = $cssnodes[0];
 		my $node = $dom->createTextNode($nodetext);
 		$cssnode->addChild($node);
-
-	    } else {
-		die "Error: multiple info/css blocks - likely a problem";
 	    }
 	}
 


### PR DESCRIPTION
There's no need to fall over if there are multiple CSS blocks; we can just add to the first one, which will hopefully mean we can over-ride settings if need be. Alternatively we could just add our own CSS block to the start of the file but let's not go there just yet.