### PR TITLE
Explicitly expand the XInclude contents for published files

### DIFF
--- a/CIAODOC.pm
+++ b/CIAODOC.pm
@@ -98,7 +98,7 @@ XML::LibXSLT->max_depth(2000);
 
 my @funcs_util =
   qw(
-     fixme dbg check_dir mymkdir mycp myrm mysetmods
+     fixme dbg check_dir mymkdir mycp mycp_xml myrm mysetmods
      check_paths check_executables check_executable_runs
      extract_filename get_ostype
      list_ahelp_sites find_ahelp_site check_ahelp_site_valid
@@ -307,6 +307,21 @@ sub mycp ($$) {
     mysetmods $out;
 
 } # sub: mycp()
+
+# Copy an XML file (expanding out any XInclude contents).
+#
+sub mycp_xml ($$) {
+    my $in  = shift;
+    my $out = shift;
+    my $name = $_[0];
+
+    my $dom = $parser->parse_file($in);
+
+    myrm $out;
+    $dom->toFile($out, 0);
+    mysetmods $out;
+
+} # sub: mycp_xml
 
 # myrm( $fname )
 #

--- a/publish.pl
+++ b/publish.pl
@@ -1864,6 +1864,12 @@ sub process_xml ($$) {
 	    next;
 	}
 
+	# The xinclude files were originally searched for because they
+	# would then be copied to the $published site (if necessary),
+	# but we now copy over the file after expanding any xinclude.
+	# We still want to know about the xinclude files as we can
+	# better check for when a file needs to be republished.
+	#
 	my @xincludes = find_xinclude_files $in;
 	$$opts{xincludes} = \@xincludes;
 
@@ -2016,16 +2022,25 @@ sub process_xml ($$) {
  	  #
 	  # TODO: Is there ever a case when we have no dependencies but want to publish?
 	  #       Should *not* be
-	  mycp "${in}.xml", "${published}/${in}.xml";
+	  #
+	  # NOTE: if the input file has XInclude statements in it, should
+	  # this be reflected in the output? One way is to copy over any
+	  # XInclude files as well. The other is that we copy over the
+	  # file after processing the XInclude files.
+	  #
+	  # This needs to copy over the XInclude files as well
+	  # mycp "${in}.xml", "${published}/${in}.xml";
+	  #
+	  mycp_xml "${in}.xml", "${published}/${in}.xml";
 
 	  # Copy over any xinclude files to the published area.
 	  # The logic is a bit unclear of why this is only done when
 	  # there are dependencies, but let's assume it's correct.
 	  #
-	  foreach my $xinclude ( @{$$opts{xincludes}} ) {
-	      dbg " - storage/published $xinclude";
-	      mycp $xinclude, "${published}/${xinclude}";
-	  }
+	  ##foreach my $xinclude ( @{$$opts{xincludes}} ) {
+	  ##    dbg " - storage/published $xinclude";
+	  ##    mycp $xinclude, "${published}/${xinclude}";
+	  ##}
 
 	  # Write the dependencies out after copying the file to the storage directory
 	  # since we check on the published copy existing when writing out the reverse


### PR DESCRIPTION
I managed to cause a tiz by using a XInclude file in something that triggers the dependency tracking, as the contents of the XInclude file were not copied over. This lead to some changes. I realised that if we copied over the file *after* expanding the XInclude then we could avoid this complication. It turns out that some of the extra code to track the XInclude files is technically useful (the tracking of whether to re-publish the file), so it wasn't all wasted.