### PR TITLE
extract_notebook: remove files if they exist 

### DIFF
--- a/extract_notebook.py
+++ b/extract_notebook.py
@@ -69,13 +69,16 @@ def convert(nbfile, outdir):
 
     # Write out the body
     out = os.path.join(outdir, head)
+    if os.path.exists(out):
+        os.unlink(out)
     open(out, 'w').write(body)
     print(out)
 
     # Write out the file contents
     for key, cnt in resources['outputs'].items():
-
         out = os.path.join(outdir, key)
+        if os.path.exists(out):
+            os.unlink(out)
         open(out, 'wb').write(cnt)
         print(out)
 


### PR DESCRIPTION
to deal with any permission issues due to user umask.

Files are removed first and then written to; if not then when `open` is called on files that are read-only the `open` fails. 

